### PR TITLE
Popup and pointer cursor

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -51,7 +51,7 @@ noinst_PROGRAMS =			\
 	test-embedded			\
 	$(NULL)
 
-test_compositor_LDADD = libwakefield.la
+test_compositor_LDADD = libwakefield.la $(GTK_LIBS)
 
 test_compositor_SOURCES =	\
 	test-compositor.c	\
@@ -59,7 +59,7 @@ test_compositor_SOURCES =	\
 
 test_compositor_CFLAGS = $(AM_CFLAGS) $(GTK_CFLAGS)
 
-test_embedding_LDADD = libwakefield.la
+test_embedding_LDADD = libwakefield.la $(GTK_LIBS)
 
 test_embedding_SOURCES =	\
 	test-embedding.c	\
@@ -69,7 +69,7 @@ test_embedding_CFLAGS = $(AM_CFLAGS) $(GTK_CFLAGS)
 
 test_embedded_CFLAGS = $(AM_CFLAGS) $(GTK_CFLAGS)
 
-test_embedded_LDADD = libwakefield.la
+test_embedded_LDADD = libwakefield.la $(GTK_LIBS)
 
 test_embedded_SOURCES =	\
 	test-embedded.c	\

--- a/Makefile.am
+++ b/Makefile.am
@@ -67,8 +67,6 @@ test_embedding_SOURCES =	\
 
 test_embedding_CFLAGS = $(AM_CFLAGS) $(GTK_CFLAGS)
 
-test_embedded_CFLAGS = $(AM_CFLAGS) $(GTK_CFLAGS)
-
 test_embedded_LDADD = libwakefield.la $(GTK_LIBS)
 
 test_embedded_SOURCES =	\

--- a/wakefield-compositor.c
+++ b/wakefield-compositor.c
@@ -48,7 +48,6 @@
 struct WakefieldPointer
 {
   struct wl_list resource_list;
-  struct wl_resource *cursor_surface;
 
   guint32 serial;
   guint32 button_count;
@@ -60,6 +59,11 @@ struct WakefieldPointer
   /* This is what we got told by gdk about the current state. The difference is
      that we don't forward enter/leave events during an implicit grab */
   struct wl_resource *current_gdk_surface;
+
+  WakefieldSurface *cursor_surface;
+  gulong cursor_surface_commit_listener;
+  int hot_x;
+  int hot_y;
 
   struct wl_client *grab_client;
   guint32 grab_button;
@@ -137,6 +141,10 @@ G_DEFINE_TYPE_WITH_PRIVATE (WakefieldCompositor, wakefield_compositor, GTK_TYPE_
 	for (resource = 0, resource = wl_resource_from_link((list)->prev);	\
 	     wl_resource_get_link(resource) != (list);				\
 	     resource = wl_resource_from_link(wl_resource_get_link(resource)->prev))
+
+static void
+unset_cursor_surface (struct WakefieldPointer *pointer,
+                      WakefieldSurface *cursor_surface);
 
 static void
 wakefield_compositor_realize (GtkWidget *widget)
@@ -378,6 +386,9 @@ send_leave (WakefieldCompositor *compositor, struct wl_resource  *surface)
   pointer->serial = wl_display_next_serial (priv->wl_display);
   if (pointer_resource)
     wl_pointer_send_leave (pointer_resource, pointer->serial, surface);
+
+  if (pointer->cursor_surface)
+    unset_cursor_surface (pointer, pointer->cursor_surface);
 }
 
 static uint32_t
@@ -981,12 +992,99 @@ unbind_resource (struct wl_resource *resource)
 }
 
 static void
+unset_cursor_surface (struct WakefieldPointer *pointer,
+                      WakefieldSurface *cursor_surface)
+{
+  g_signal_handler_disconnect (cursor_surface,
+                               pointer->cursor_surface_commit_listener);
+  g_object_remove_weak_pointer (G_OBJECT (cursor_surface),
+                                (gpointer*)&pointer->cursor_surface);
+  pointer->cursor_surface = NULL;
+}
+
+static void
+pointer_cursor_surface_committed (WakefieldSurface *surface,
+                                  GdkWindow *window)
+{
+  WakefieldCompositor *compositor = wakefield_surface_get_compositor (surface);
+  WakefieldCompositorPrivate *priv =
+    wakefield_compositor_get_instance_private (compositor);
+  struct WakefieldPointer *pointer = &priv->seat.pointer;
+  cairo_surface_t *cursor_surface;
+
+  cursor_surface = wakefield_surface_create_cairo_surface (surface);
+  if (cursor_surface)
+    {
+      GdkCursor *gdk_cursor;
+
+      gdk_cursor = gdk_cursor_new_from_surface (gdk_window_get_display (window),
+                                                cursor_surface,
+                                                pointer->hot_x, pointer->hot_y);
+      cairo_surface_destroy (cursor_surface);
+      gdk_window_set_cursor (window, gdk_cursor);
+      g_object_unref (gdk_cursor);
+    }
+}
+
+static void
 pointer_set_cursor (struct wl_client *client,
                     struct wl_resource *resource,
                     uint32_t serial,
                     struct wl_resource *surface_resource,
                     int32_t x, int32_t y)
 {
+  struct WakefieldPointer *pointer = wl_resource_get_user_data (resource);
+  WakefieldSurface *cursor_surface = NULL;
+  GdkWindow *window;
+
+  if (surface_resource)
+    {
+      cursor_surface = wl_resource_get_user_data (surface_resource);
+
+      switch (wakefield_surface_get_role (surface_resource))
+        {
+        case WAKEFIELD_SURFACE_ROLE_NONE:
+        case WAKEFIELD_SURFACE_ROLE_POINTER_CURSOR:
+          break;
+        case WAKEFIELD_SURFACE_ROLE_XDG_SURFACE:
+        case WAKEFIELD_SURFACE_ROLE_XDG_POPUP:
+          wl_resource_post_error (resource, WL_POINTER_ERROR_ROLE,
+                                  "This wl_surface already has a role");
+          break;
+        }
+
+      wakefield_surface_set_role (surface_resource,
+                                  WAKEFIELD_SURFACE_ROLE_POINTER_CURSOR);
+    }
+
+  if (pointer->serial != serial)
+    return;
+
+  if (pointer->current_surface == NULL)
+    return;
+
+  if (pointer->cursor_surface == cursor_surface)
+    return;
+
+  if (pointer->cursor_surface)
+    unset_cursor_surface (pointer, pointer->cursor_surface);
+
+  if (cursor_surface)
+    {
+      window = wakefield_surface_get_window (pointer->current_surface);
+      pointer->hot_x = x;
+      pointer->hot_y = y;
+      pointer->cursor_surface_commit_listener =
+        g_signal_connect_object (cursor_surface, "committed",
+                                 G_CALLBACK (pointer_cursor_surface_committed),
+                                 window, 0);
+      pointer->cursor_surface = cursor_surface;
+      g_object_add_weak_pointer (G_OBJECT (cursor_surface),
+                                 (gpointer*)&pointer->cursor_surface);
+      pointer_cursor_surface_committed (cursor_surface, window);
+    }
+  else
+    pointer->cursor_surface = NULL;;
 }
 
 static const struct wl_pointer_interface pointer_implementation = {

--- a/wakefield-compositor.c
+++ b/wakefield-compositor.c
@@ -636,8 +636,6 @@ wakefield_compositor_send_leave (WakefieldCompositor *compositor,
 {
   WakefieldCompositorPrivate *priv = wakefield_compositor_get_instance_private (compositor);
   struct WakefieldPointer *pointer = &priv->seat.pointer;
-  struct wl_resource *pointer_resource;
-  uint32_t serial = wl_display_next_serial (priv->wl_display);
   gboolean has_implicit_grab;
 
   if (surface == NULL)
@@ -658,13 +656,7 @@ wakefield_compositor_send_leave (WakefieldCompositor *compositor,
   g_assert (pointer->current_surface == surface);
   pointer->current_surface = NULL;
 
-  pointer_resource = wakefield_compositor_get_pointer_for_client (compositor,
-                                                                  wl_resource_get_client (surface));
-  if (pointer_resource)
-    {
-      wl_pointer_send_leave (pointer_resource, serial,
-                             surface);
-    }
+  send_leave (compositor, surface);
 }
 
 static void

--- a/wakefield-private.h
+++ b/wakefield-private.h
@@ -25,6 +25,8 @@
 
 #include <wayland-server.h>
 
+typedef struct _WakefieldSurface WakefieldSurface;
+
 struct wl_display * wakefield_compositor_get_display            (WakefieldCompositor *compositor);
 void                wakefield_compositor_surface_unmapped       (WakefieldCompositor *compositor,
                                                                  struct wl_resource  *surface);
@@ -49,7 +51,8 @@ void                wakefield_compositor_send_motion            (WakefieldCompos
 typedef enum {
   WAKEFIELD_SURFACE_ROLE_NONE,
   WAKEFIELD_SURFACE_ROLE_XDG_SURFACE,
-  WAKEFIELD_SURFACE_ROLE_XDG_POPUP
+  WAKEFIELD_SURFACE_ROLE_XDG_POPUP,
+  WAKEFIELD_SURFACE_ROLE_POINTER_CURSOR,
 } WakefieldSurfaceRole;
 
 struct wl_resource * wakefield_surface_new              (WakefieldCompositor *compositor,
@@ -65,6 +68,9 @@ void                 wakefield_surface_set_role         (struct wl_resource *sur
                                                          WakefieldSurfaceRole role);
 GdkWindow *          wakefield_surface_get_window       (struct wl_resource  *surface_resource);
 gboolean             wakefield_surface_is_mapped        (struct wl_resource  *surface_resource);
+
+WakefieldCompositor *wakefield_surface_get_compositor   (WakefieldSurface *surface);
+cairo_surface_t *    wakefield_surface_create_cairo_surface (WakefieldSurface *surface);
 
 struct wl_resource *wakefield_xdg_surface_new (struct wl_client   *client,
                                                struct wl_resource *shell_resource,

--- a/wakefield-private.h
+++ b/wakefield-private.h
@@ -61,6 +61,8 @@ void                 wakefield_surface_draw             (struct wl_resource  *su
 struct wl_resource * wakefield_surface_get_xdg_surface  (struct wl_resource  *surface_resource);
 struct wl_resource * wakefield_surface_get_xdg_popup    (struct wl_resource  *surface_resource);
 WakefieldSurfaceRole wakefield_surface_get_role         (struct wl_resource  *surface_resource);
+void                 wakefield_surface_set_role         (struct wl_resource *surface_resource,
+                                                         WakefieldSurfaceRole role);
 GdkWindow *          wakefield_surface_get_window       (struct wl_resource  *surface_resource);
 gboolean             wakefield_surface_is_mapped        (struct wl_resource  *surface_resource);
 

--- a/wakefield-surface.c
+++ b/wakefield-surface.c
@@ -61,6 +61,8 @@ struct _WakefieldSurface
   WakefieldCompositor *compositor;
   struct wl_resource *resource;
 
+  WakefieldSurfaceRole role;
+
   struct WakefieldXdgSurface *xdg_surface;
   struct WakefieldXdgPopup *xdg_popup;
 
@@ -117,13 +119,19 @@ wakefield_surface_get_role (struct wl_resource  *surface_resource)
 {
   WakefieldSurface *surface = wl_resource_get_user_data (surface_resource);
 
-  if (surface->xdg_surface)
-    return WAKEFIELD_SURFACE_ROLE_XDG_SURFACE;
+  return surface->role;
+}
 
-  if (surface->xdg_popup)
-    return WAKEFIELD_SURFACE_ROLE_XDG_POPUP;
+void
+wakefield_surface_set_role (struct wl_resource *surface_resource,
+                            WakefieldSurfaceRole role)
+{
+  WakefieldSurface *surface = wl_resource_get_user_data (surface_resource);
 
-  return WAKEFIELD_SURFACE_ROLE_NONE;
+  g_assert (surface->role == WAKEFIELD_SURFACE_ROLE_NONE ||
+            surface->role == role);
+
+  surface->role = role;
 }
 
 gboolean
@@ -734,6 +742,9 @@ wakefield_xdg_surface_new (struct wl_client *client,
   WakefieldSurface *surface = wl_resource_get_user_data (surface_resource);
   struct WakefieldXdgSurface *xdg_surface;
 
+  wakefield_surface_set_role (surface_resource,
+                              WAKEFIELD_SURFACE_ROLE_XDG_SURFACE);
+
   xdg_surface = g_slice_new0 (struct WakefieldXdgSurface);
   xdg_surface->surface = surface;
 
@@ -915,6 +926,9 @@ wakefield_xdg_popup_new (WakefieldCompositor *compositor,
   WakefieldSurface *parent_surface = wl_resource_get_user_data (parent_resource);
   struct WakefieldXdgPopup *xdg_popup;
   GdkWindow *popup_window;
+
+  wakefield_surface_set_role (surface_resource,
+                              WAKEFIELD_SURFACE_ROLE_XDG_SURFACE);
 
   xdg_popup = g_slice_new0 (struct WakefieldXdgPopup);
   xdg_popup->surface = surface;


### PR DESCRIPTION
Some patches. I tried it out and tried to make popups behave as popups on Wayland and to make wl_pointer.set_cursor work. The first needed the slightly ugly "POPUP_MENU" hack, but thats probably as good as it gets if we want to use xdg_shell, not change the GDK API and don't not change how the Wayland backend knows when to create xdg_popups.

Also menus are padded with extra gray area and are without shadow. Didn't look into why.
